### PR TITLE
Adding the ability to use .obj files that have quads instead of triangles.

### DIFF
--- a/webgl-obj-loader.js
+++ b/webgl-obj-loader.js
@@ -53,7 +53,19 @@ function Mesh( objectData ){
       // if this is a face
       else if( lines[ i ].startsWith( 'f ' ) ){
         line = lines[ i ].slice( 2 ).split( " " );
+        var quad = false;
         for(var j=0; j<line.length; j++){
+            // Triangulating quads
+            // quad: 'f v0/t0/vn0 v1/t1/vn1 v2/t2/vn2 v3/t3/vn3/'
+            // corresponding triangles:
+            //      'f v0/t0/vn0 v1/t1/vn1 v2/t2/vn2'
+            //      'f v2/t2/vn2 v3/t3/vn3 v0/t0/vn0'
+            if(j == 3 && !quad) {
+                // add v2/t2/vn2 in again before continuing to 3
+                j = 2;
+                quad = true;
+            }
+
             if( line[ j ] in packed.hashindices ){
                 packed.indices.push( packed.hashindices[ line[ j ] ] );
             }
@@ -75,6 +87,11 @@ function Mesh( objectData ){
                 packed.indices.push( packed.index );
                 // increment the counter
                 packed.index += 1;
+            }
+
+            if(j == 3 && quad) {
+                // add v0/t0/vn0 onto the second triangle
+                packed.indices.push( packed.hashindices[ line[ 0 ] ] );
             }
         }
       }


### PR DESCRIPTION
When looking for some good free .obj files to use, I found that a lot of them tended to have quads. I took one of them and manually made it into triangles, then realized that the same thing could be accomplished within the obj-loader itself. I have heard that it is possible to do this in something like blender too, but I'm sure I'm not alone in that I don't have any software like that.

The changes I made have no affect on properly triangulated objects. They only take effect when faces have more than 3 sets of items (assuming that means they are quads). I tested it on several objects, and it worked as I would have expected. It even resulted in having less vertices than the object I had triangulated manually.

Let me know if you have any questions or issues with it. It is entirely possible that I didn't think of something.
