### PR TITLE
Add support for separating mesh indices by materials

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -114,6 +114,9 @@ export function downloadModels (models) {
       );
     }
 
+    let options = {};
+    options.indicesPerMaterial = !!model.indicesPerMaterial;    
+
     // if the name is not provided, dervive it from the given OBJ
     let name = model.name;
     if (!name) {
@@ -126,7 +129,7 @@ export function downloadModels (models) {
       fetch(model.obj)
         .then((response) => response.text())
         .then((data) => {
-          return new Mesh(data);
+          return new Mesh(data, options);
         })
     );
 


### PR DESCRIPTION
Currently the library requires the user to upload all material data to the shader and index the data by vertex-attribute-bound material id's.

The main problem with this is that obj's with several materials such as the [crytek sponza](http://www.crytek.com/cryengine/cryengine3/downloads) contains lots of textures. This will quickly make the user run out of texture units when uploading all material data to the shader (which happens over >16 units on my machine). Texture arrays can't be used either if the images are not the same size, which is often the case. 

This PR gives an option to divide the mesh indices into separate arrays which are accessed by the material indices. By doing this, the mesh is instead divided into sub-meshes that can have a separate shader per material. This resolves #44