### PR TITLE
Add calculation of tangents and bitangents

### DIFF
--- a/src/mesh.js
+++ b/src/mesh.js
@@ -304,6 +304,15 @@ export default class Mesh {
         }
     }
 
+    /**
+     * Calculates the tangents and bitangents of the mesh that forms an orthogonal basis together with the
+     * normal in the direction of the texture coordinates. These are useful for setting up the TBN matrix
+     * when distorting the normals through normal maps.
+     * Method derived from: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-13-normal-mapping/
+     * 
+     * This method requires the normals and texture coordinates to be parsed and set up correctly.
+     * Adds the tangents and bitangents as members of the class instance.
+     */
     calculateTangentsAndBitangents() {
         console.assert(this.vertices && this.vertices.length &&
             this.vertexNormals && this.vertexNormals.length &&
@@ -317,7 +326,6 @@ export default class Mesh {
         let indices;
         // If sorted by material
         if (Array.isArray(this.indices[0])) {
-            debugger;
             indices = [].concat.apply([], this.indices);
         } else {
             indices = this.indices;

--- a/src/mesh.js
+++ b/src/mesh.js
@@ -298,6 +298,10 @@ export default class Mesh {
         self.materialNames = materialNamesByIndex;
         self.materialIndices = materialIndicesByName;
         self.materialsByIndex = {};
+
+        if (options.calcTangentsAndBitangents) {
+            this.calculateTangentsAndBitangents();
+        }
     }
 
     calculateTangentsAndBitangents() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,6 +116,7 @@ export function downloadModels (models) {
 
     let options = {};
     options.indicesPerMaterial = !!model.indicesPerMaterial;    
+    options.calcTangentsAndBitangents = !!model.calcTangentsAndBitangents;
 
     // if the name is not provided, dervive it from the given OBJ
     let name = model.name;

--- a/test/mesh.js
+++ b/test/mesh.js
@@ -160,6 +160,12 @@ describe('Mesh', function() {
     const bitangents = m.bitangents;
     const normals = m.vertexNormals;
 
+    it('should contain tangents, bitangents and normals with the same length', function() {
+      const normalsLength = normals.length;
+      expect(tangents).to.have.length(normalsLength);
+      expect(bitangents).to.have.length(normalsLength);
+    });
+
     it('should contain tangents orthogonal to normals', function () {
       let res = [];
       for (let i = 0; i < normals.length; i += 3) {

--- a/test/mesh.js
+++ b/test/mesh.js
@@ -140,4 +140,56 @@ describe('Mesh', function() {
     });
   });
 
+  describe('Test tangents and bitangent calculation', function () {
+    const data = `
+    v 0 0 0
+    v 0 1 0
+    v 1 0 0
+
+    vn 0 0 1
+
+    vt 0.0 0.0
+    vt 0.1 0.1
+
+    f 1/1/1 2/2/1 3/2/1
+    `
+
+    const m = new Mesh(data);
+    m.calculateTangentsAndBitangents();
+    const tangents = m.tangents;
+    const bitangents = m.bitangents;
+    const normals = m.vertexNormals;
+
+    it('should contain tangents orthogonal to normals', function () {
+      let res = [];
+      for (let i = 0; i < normals.length; i += 3) {
+        const nx = normals[i + 0];
+        const ny = normals[i + 1];
+        const nz = normals[i + 2];
+
+        const tx = tangents[i + 0];
+        const ty = tangents[i + 1];
+        const tz = tangents[i + 2];
+
+        res.push(nx * tx + ny * ty + nz * tz);
+      }
+      res.every(i => expect(i).to.be.closeTo(0, 0.01));
+    });
+
+    it('should contain bitangents orthogonal to normals', function () {
+      let res = [];
+      for (let i = 0; i < normals.length; i += 3) {
+        const nx = normals[i + 0];
+        const ny = normals[i + 1];
+        const nz = normals[i + 2];
+
+        const bx = bitangents[i + 0];
+        const by = bitangents[i + 1];
+        const bz = bitangents[i + 2];
+
+        res.push(nx * bx + ny * by + nz * bz);
+      }
+      res.every(i => expect(i).to.be.closeTo(0, 0.01));
+    });
+  });
 });


### PR DESCRIPTION
Calculate tangents and bitangents in mesh class (useful for setting up the TBN matrix when dealing with bump maps). Method from: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-13-normal-mapping/ Resolves #49 

* Make tangent and bitangent orthogonal to normal using Gram-Schmidt orthogonalization.
* A bit messy without matrix lib, but doesn't add any dependency atleast

Still TODO: Check handedness. UV's might be oriented in a wrong way (could be the case when dealing with symmetric models). 