### PR TITLE
Fixed file extensions for native modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import Mesh from "./mesh";
-import { Material, MaterialLibrary } from "./material";
-import { Layout } from "./layout";
-import { downloadModels, downloadMeshes, initMeshBuffers, deleteMeshBuffers } from "./utils";
+import Mesh from "./mesh.js";
+import { Material, MaterialLibrary } from "./material.js";
+import { Layout } from "./layout.js";
+import { downloadModels, downloadMeshes, initMeshBuffers, deleteMeshBuffers } from "./utils.js";
 
 const version = "1.1.3";
 

--- a/src/mesh.js
+++ b/src/mesh.js
@@ -1,4 +1,4 @@
-import { Layout } from "./layout";
+import { Layout } from "./layout.js";
 
 /**
  * The main Mesh class. The constructor will parse through the OBJ file data

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
-import Mesh from "./mesh";
-import { Material, MaterialLibrary } from "./material";
-import { Layout } from "./layout";
+import Mesh from "./mesh.js";
+import { Material, MaterialLibrary } from "./material.js";
+import { Layout } from "./layout.js";
 
 function downloadMtlTextures(mtl, root) {
     const mapAttributes = [


### PR DESCRIPTION
I added file extensions to the script module imports. This has no effect on Rollup, while allowing native imports with Chromium and future versions of Firefox. Native imports let developers use an index-dev.html for development without having to run a build process on every change, but still allows bundling the scripts with Rollup for deployment. It's a trivial change that makes it faster to incrementally modify scripts.