### PR TITLE
Test: Add test for triangulation bugs

### DIFF
--- a/test/mesh.ts
+++ b/test/mesh.ts
@@ -139,6 +139,41 @@ describe('Mesh', function () {
       ]);
     });
 
+    it('should allow reuse of existing verts when parsing quads', function () {
+      const data = `
+      v 0 0 0
+      v 1 1 1
+      v 2 2 2
+      v 3 3 3
+      v 4 4 4
+      v 5 5 5
+
+      vn 0 0 0
+      vn 1 1 1
+      vn 2 2 2
+      vn 3 3 3
+      vn 4 4 4
+      vn 5 5 5
+
+      vt 0.0 0.0
+      vt 0.1 0.1
+      vt 0.2 0.2
+      vt 0.3 0.3
+      vt 0.4 0.4
+      vt 0.5 0.5
+
+      f 1/1/1 2/2/2 3/3/3 4/4/4
+      f 5/5/5 6/6/6 1/1/1 2/2/2
+      `
+      const m = new Mesh(data);
+      expect(m.indices).to.deep.equal([
+        0, 1, 2, 2, 3, 0, 4, 5, 0, 0, 1, 4
+      ]);
+      expect(m.vertices).to.deep.equal([
+        0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5
+      ]);
+    });
+
     it('should triangulate n-gons', function () {
       const data = `
       v 0 0 0


### PR DESCRIPTION
This commit adds a test for the bug in an earlier commit where triangles
from triangulation were being ignored.